### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/azure/functions/requirements.txt
+++ b/azure/functions/requirements.txt
@@ -31,7 +31,7 @@ openai==1.73.0
 packaging==24.2
 platformdirs==4.3.6
 pluggy==1.5.0
-pyautogen==0.8.6
+ag2==0.8.6
 pydantic==2.10.6
 pydantic_core==2.27.2
 Pygments==2.19.1

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -31,7 +31,7 @@ packaging==24.2
 passlib==1.7.4
 pluggy==1.5.0
 pyasn1==0.4.8
-pyautogen==0.8.7
+ag2==0.8.7
 pycparser==2.22
 pydantic==2.11.3
 pydantic-settings==2.9.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
